### PR TITLE
fix: pass track and version code to supply action

### DIFF
--- a/lib/fastlane/plugin/fossify/actions/metadata_android.rb
+++ b/lib/fastlane/plugin/fossify/actions/metadata_android.rb
@@ -8,12 +8,16 @@ module Fastlane
       def self.run(params)
         json_key = params[:json_key]
         package_name = params[:package_name]
+        track = params[:track]
+        version_code = params[:version_code]
         dryrun = params[:validate_only]
 
         Actions::SupplyAction.run(
           json_key:,
           metadata_path: 'fastlane/metadata/android',
           package_name:,
+          track:,
+          version_code:,
           skip_upload_aab: true,
           skip_upload_apk: true,
           validate_only: dryrun
@@ -24,6 +28,8 @@ module Fastlane
         [
           opt(:json_key, required: true),
           opt(:package_name, required: true),
+          opt(:track, required: false, default_value: 'production'),
+          opt(:version_code, required: true, type: Integer),
           opt(:validate_only, required: false, type: Boolean, default_value: false)
         ]
       end

--- a/lib/fastlane/plugin/fossify/version.rb
+++ b/lib/fastlane/plugin/fossify/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Fossify
-    VERSION = '1.0.0'
+    VERSION = '1.0.1'
   end
 end

--- a/spec/metadata_android_action_spec.rb
+++ b/spec/metadata_android_action_spec.rb
@@ -8,6 +8,7 @@ describe Fastlane::Actions::MetadataAndroidAction do
       params = {
         package_name: 'org.fossify.app',
         json_key: 'path/to/key.json',
+        track: 'production',
         validate_only: false
       }
 
@@ -16,6 +17,7 @@ describe Fastlane::Actions::MetadataAndroidAction do
                 metadata_path: 'fastlane/metadata/android',
                 package_name: 'org.fossify.app',
                 json_key: 'path/to/key.json',
+                track: 'production',
                 skip_upload_aab: true,
                 skip_upload_apk: true,
                 validate_only: false


### PR DESCRIPTION
- The metadata action now actually works.
- Bumped version to 1.0.1