### PR TITLE
fix: set completed Play release status

### DIFF
--- a/lib/fastlane/plugin/fossify/actions/deploy_android.rb
+++ b/lib/fastlane/plugin/fossify/actions/deploy_android.rb
@@ -30,6 +30,7 @@ module Fastlane
           package_name: params[:package_name],
           json_key: params[:json_key],
           metadata_path: params[:metadata_path],
+          release_status: 'completed',
           skip_upload_apk: true,
           skip_upload_metadata: false,
           track: params[:track],

--- a/lib/fastlane/plugin/fossify/version.rb
+++ b/lib/fastlane/plugin/fossify/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module Fossify
-    VERSION = '1.0.2'
+    VERSION = '1.0.3'
   end
 end

--- a/spec/deploy_android_action_spec.rb
+++ b/spec/deploy_android_action_spec.rb
@@ -28,6 +28,7 @@ describe Fastlane::Actions::DeployAndroidAction do
                 package_name: 'org.fossify.app',
                 json_key: 'path/to/key.json',
                 metadata_path: 'fastlane/metadata/android',
+                release_status: 'completed',
                 track: 'production',
                 rollout: '0.05',
                 skip_upload_apk: true,


### PR DESCRIPTION
Set `release_status` to `completed` for Play uploads so 100% releases do not omit the required status. Fastlane still changes partial rollouts to `inProgress`.

This also bumps the plugin version to 1.0.3 and updates the deploy action spec.

Tested: `BUNDLE_PATH=vendor/bundle bundle exec rake`